### PR TITLE
Fix hardcoded lib path

### DIFF
--- a/lib/aubio/aubio-ffi.rb
+++ b/lib/aubio/aubio-ffi.rb
@@ -4,7 +4,9 @@ require 'ffi'
 
 module Aubio::Api
   extend FFI::Library
-  ffi_lib "/usr/local/Cellar/aubio/0.4.4/lib/libaubio.dylib"
+  lib_paths = Array(ENV["AUBIO_LIB"] || Dir["/{opt,usr}/{,local/}{lib,lib64,Cellar/aubio**}/libaubio.{*.dylib,so.*}"])
+  fallback_names = %w(libaubio.4.2.2.dylib libaubio.so.1 aubio1.dll)
+  ffi_lib(lib_paths + fallback_names)
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e


### PR DESCRIPTION
Use example from legacy api file - was throwing an error when running Sonic Pi against gems installed in system (rather than vendor)